### PR TITLE
Arch Linux path finding fix

### DIFF
--- a/runners/proton-launcher.sh
+++ b/runners/proton-launcher.sh
@@ -390,7 +390,7 @@ run_proton="
 	SteamAppId=$appid \\
 	${proton_extra_envs[*]} \\
 	\\
-	'$proton_dir/proton' run '$executable' $([ -n "$1" ] && printf " '%s'" "$@")
+	'$proton_dir/proton' runinprefix '$executable' $([ -n "$1" ] && printf " '%s'" "$@")
 "
 
 echo -e "\n$run_proton\n"

--- a/utils/find-library-for-appid.sh
+++ b/utils/find-library-for-appid.sh
@@ -12,6 +12,7 @@ fi
 steam_install_candidates=( \
 	"$steam_dir" \
 	"$HOME/.var/app/com.valvesoftware.Steam/.local/share/Steam" \
+	"$HOME/.local/share/Steam" \
 )
 for steam_install in "${steam_install_candidates[@]}"; do
 	echo "Searching for Steam in '$steam_install'" >&2


### PR DESCRIPTION
Lutris fails to find games on Arch because of a path finding issue. This adds the path where games are stored on Arch to the array. It may need to have an if statement added to detect OS if this causes issues on the other operating systems. 